### PR TITLE
Simplify FrameRateType RegExp

### DIFF
--- a/conformance/MPDValidator/schemas/DASH-MPD.xsd
+++ b/conformance/MPDValidator/schemas/DASH-MPD.xsd
@@ -144,7 +144,7 @@
   <!-- Type for Frame Rate -->
   <xs:simpleType name="FrameRateType">
     <xs:restriction base="xs:string">
-      <xs:pattern value="[0-9]*[0-9](/[0-9]*[0-9])?"/>
+      <xs:pattern value="[0-9]+(/[0-9]+)?"/>
     </xs:restriction>
   </xs:simpleType>
  


### PR DESCRIPTION
Minor modification for the `FrameRateType` descriptor.

Based on my general knowledge and [tutorials](http://www.regular-expressions.info/repeat.html) for regular expression it is safe to say these two patterns are equivalent to each other.
But I couldn't find limitation in MPD, neither could use the binaries in the repository to verify this assumption. It would be great to check this before the merge.
