### PR TITLE
Simplify regex in DASH-MPD schema

### DIFF
--- a/conformance/MPDValidator/schemas/DASH-MPD.xsd
+++ b/conformance/MPDValidator/schemas/DASH-MPD.xsd
@@ -148,7 +148,7 @@
   <!-- Type for Frame Rate -->
   <xs:simpleType name="FrameRateType">
     <xs:restriction base="xs:string">
-      <xs:pattern value="[0-9]*[0-9](/[0-9]*[0-9])?"/>
+      <xs:pattern value="[0-9]+(/[0-9]+)?"/>
     </xs:restriction>
   </xs:simpleType>
  


### PR DESCRIPTION
In this pattern the _creator_ wanted to achieve to have at least one number with doubling the `[0-9]` and adding `*` to one of them. Although it works but weird to see pattern like this because of the following:

The [Regex Tutorial](http://www.regular-expressions.info/repeat.html) tells the asterisk and the plus operator basically the same, the only difference is `+` demands to have at least one occurrence.  
With that we have a much simplier pattern which doesn't confuse others and works as the previous one.
