### PR TITLE
Changes for resolution,ac-4 checks

### DIFF
--- a/conformance/ISOSegmentValidator/public/src/ValidateAtomList.cpp
+++ b/conformance/ISOSegmentValidator/public/src/ValidateAtomList.cpp
@@ -365,7 +365,9 @@ OSErr Validate_minf_Atom( atomOffsetEntry *aoe, void *refcon )
 		default:
 			warnprint("WARNING: unknown media type '%s'\n",ostypetostr(tir->mediaType));
 	}
-
+                 //Explicit check for ac-4
+		if(!strcmp(vg.codecs, "ac-4") && strcmp(ostypetostr(tir->mediaType),"soun"))
+		    warnprint("Media Information Header Box should contain Sound Media Header Box for 'ac-4'\n" );	
 
 	// Process 'dinf' atoms
 	atomerr = ValidateAtomOfType( 'dinf', kTypeAtomFlagMustHaveOne | kTypeAtomFlagCanHaveAtMostOne, 

--- a/conformance/ISOSegmentValidator/public/src/ValidateAtoms.cpp
+++ b/conformance/ISOSegmentValidator/public/src/ValidateAtoms.cpp
@@ -349,6 +349,16 @@ OSErr Validate_tkhd_Atom( atomOffsetEntry *aoe, void *refcon )
 
 
 	// All done
+		// Check whether height and width are matching with those from MPD
+		if(EndianS16_BtoN(EndianS32_NtoB(tkhdHeadCommon.trackWidth)) != vg.width)
+		{ 
+		  errprint("Width in TrackHeaderBox is not matching with out of box width information \n");
+		}
+		if(EndianS16_BtoN(EndianS32_NtoB(tkhdHeadCommon.trackHeight))!= vg.height)
+		{ 
+		  errprint("Height in TrackHeaderBox is not matching with out of box height information \n");
+		}
+		
 	aoe->aoeflags |= kAtomValidated;
 
 bail:
@@ -508,6 +518,10 @@ OSErr Validate_mdia_hdlr_Atom( atomOffsetEntry *aoe, void *refcon )
 			"'hdlr' handler type must be be one of ", 
 			('odsm', 'crsm', 'sdsm', 'vide', 'soun', 'm7sm', 'ocsm', 'ipsm', 'mjsm', 'hint') );
 
+		//Explicit check for ac-4
+		if(!strcmp(vg.codecs, "ac-4") && strcmp(ostypetostr(hdlrInfo->componentSubType),"soun"))
+		    warnprint("handler_type is not 'soun', 'soun' is expected for 'ac-4'\n" );	
+	
 	tir->hdlrInfo = hdlrInfo;
 	// All done
 	atomprint("/>\n"); 
@@ -2824,9 +2838,9 @@ OSErr Validate_soun_SD_Entry( atomOffsetEntry *aoe, void *refcon )
 	atomprint(">\n"); //vg.tabcnt++; 
 
 	// Check required field values
-	FieldMustBeOneOf2( sdh.sdType, OSType, "SampleDescription sdType must be 'mp4a' or 'enca' ", ( 'mp4a', 'enca' ) );
+	FieldMustBeOneOf3( sdh.sdType, OSType, "SampleDescription sdType must be 'mp4a' or 'enca' or 'ac-4' ", ( 'mp4a', 'enca','ac-4' ) );
 	
-	if( (sdh.sdType != 'mp4a') && (sdh.sdType != 'enca') && !fileTypeKnown ){	
+	if( (sdh.sdType != 'mp4a') && (sdh.sdType != 'enca') && (sdh.sdType != 'ac-4') && !fileTypeKnown ){	
 			warnprint("WARNING: Don't know about this sound descriptor type \"%s\"\n", 
 				ostypetostr(sdh.sdType));
 			// goto bail;

--- a/conformance/ISOSegmentValidator/public/src/ValidateMP4.cpp
+++ b/conformance/ISOSegmentValidator/public/src/ValidateMP4.cpp
@@ -140,6 +140,8 @@ int main(void)
     vg.checkSubSegAlignment = false;
     vg.minBufferTime = -1;
     vg.bandwidth = -1;
+    vg.width = 0;
+    vg.height = 0;
     vg.suggestBandwidth = false;
     vg.isoLive = false;
     vg.isoondemand = false;
@@ -240,6 +242,13 @@ int main(void)
 
 
 
+		} else if ( keymatch( arg, "width", 5 ) ) {
+                          getNextArgStr( &temp, "width" ); vg.width = atoi(temp);
+                } else if ( keymatch( arg, "height", 6 ) ) {
+                          getNextArgStr( &temp, "height" ); vg.height = atoi(temp);
+		} else if ( keymatch( arg, "codecs", 6 ) ) {
+                          getNextArgStr( &vg.codecs, "codecs" ); 
+                 		  			  
 		} else {
 			fprintf( stderr, "Unexpected option \"%s\"\n", arg);
 			err = -1;
@@ -315,6 +324,11 @@ int main(void)
     if((vg.minBufferTime == -1) != (vg.bandwidth == -1))
     {
         fprintf( stderr, "minBufferTime and bandwidth must be provided together as options!\n" );
+        goto usageError;
+    }
+    if((vg.width == 0) != (vg.height == 0))
+    {
+        fprintf( stderr, "width and height must be provided together as options!\n" );
         goto usageError;
     }
 
@@ -491,6 +505,8 @@ usageError:
 	fprintf( stderr, "    -ssegal -         Check Subegment alignment based on <Leaf Info File>\n" );
 	fprintf( stderr, "    -bandwidth        For checking @bandwidth/@minBufferTime\n" );
 	fprintf( stderr, "    -minbuffertime    For checking @bandwidth/@minBufferTime\n" );
+	fprintf( stderr, "    -width            For checking width\n" );
+	fprintf( stderr, "    -height           For checking height\n" );
 	fprintf( stderr, "    -sbw              Suggest a good @bandwidth if the one provided is non-conforming\n" );
 	fprintf( stderr, "    -isolive          Make checks specific for media segments conforming to ISO Base media file format live profile\n" );
 	fprintf( stderr, "    -isoondemand      Make checks specific for media segments conforming to ISO Base media file format On Demand profile\n" );

--- a/conformance/ISOSegmentValidator/public/src/ValidateMP4.h
+++ b/conformance/ISOSegmentValidator/public/src/ValidateMP4.h
@@ -596,6 +596,9 @@ typedef struct {
     int  startWithSAP;
     long double  minBufferTime;
     SInt64  bandwidth;
+    unsigned int  width;
+    unsigned int  height;
+    argstr codecs;
 	bool	suggestBandwidth;
     bool    isoLive;
     bool    isoondemand;

--- a/conformance/MPDValidator/schematron/output/val_schema.xsl
+++ b/conformance/MPDValidator/schematron/output/val_schema.xsl
@@ -374,16 +374,16 @@
 
 		    <!--ASSERT -->
 <xsl:choose>
-         <xsl:when test="if (not(@profiles) or (contains(@profiles, 'urn:mpeg:dash:profile:isoff-on-demand:2011') or contains(@profiles, 'urn:mpeg:dash:profile:isoff-live:2011') or contains(@profiles, 'urn:mpeg:dash:profile:isoff-main:2011') or contains(@profiles, 'urn:mpeg:dash:profile:full:2011') or contains(@profiles, 'urn:mpeg:dash:profile:mp2t-main:2011') or contains(@profiles, 'urn:mpeg:dash:profile:mp2t-simple:2011'))) then true() else false()"/>
+         <xsl:when test="if (not(@profiles) or (contains(@profiles, 'urn:mpeg:dash:profile:isoff-on-demand:2011') or contains(@profiles, 'urn:mpeg:dash:profile:isoff-live:2011') or contains(@profiles, 'urn:mpeg:dash:profile:isoff-main:2011') or contains(@profiles, 'urn:mpeg:dash:profile:full:2011') or contains(@profiles, 'urn:mpeg:dash:profile:mp2t-main:2011') or contains(@profiles, 'urn:mpeg:dash:profile:mp2t-simple:2011') or contains (@profiles, 'http://dashif.org/guidelines/dashif#ac-4'))) then true() else false()"/>
          <xsl:otherwise>
             <svrl:failed-assert xmlns:xs="http://www.w3.org/2001/XMLSchema"
                                 xmlns:schold="http://www.ascc.net/xml/schematron"
                                 xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
-                                test="if (not(@profiles) or (contains(@profiles, 'urn:mpeg:dash:profile:isoff-on-demand:2011') or contains(@profiles, 'urn:mpeg:dash:profile:isoff-live:2011') or contains(@profiles, 'urn:mpeg:dash:profile:isoff-main:2011') or contains(@profiles, 'urn:mpeg:dash:profile:full:2011') or contains(@profiles, 'urn:mpeg:dash:profile:mp2t-main:2011') or contains(@profiles, 'urn:mpeg:dash:profile:mp2t-simple:2011'))) then true() else false()">
+                                test="if (not(@profiles) or (contains(@profiles, 'urn:mpeg:dash:profile:isoff-on-demand:2011') or contains(@profiles, 'urn:mpeg:dash:profile:isoff-live:2011') or contains(@profiles, 'urn:mpeg:dash:profile:isoff-main:2011') or contains(@profiles, 'urn:mpeg:dash:profile:full:2011') or contains(@profiles, 'urn:mpeg:dash:profile:mp2t-main:2011') or contains(@profiles, 'urn:mpeg:dash:profile:mp2t-simple:2011') or contains (@profiles, 'http://dashif.org/guidelines/dashif#ac-4'))) then true() else false()">
                <xsl:attribute name="location">
                   <xsl:apply-templates select="." mode="schematron-get-full-path"/>
                </xsl:attribute>
-               <svrl:text>The On-Demand profile shall be identified by the URN "urn:mpeg:dash:profile:isoff-on-demand:2011". The live profile shall be identified by the URN "urn:mpeg:dash:profile:isoff-live:2011". The main profile shall be identified by the URN "urn:mpeg:dash:profile:isoff-main:2011". The full profile shall be identified by the URN "urn:mpeg:dash:profile:full:2011". The mp2t-main profile shall be identified by the URN "urn:mpeg:dash:profile:mp2t-main:2011". The mp2t-simple profile shall be identified by the URN "urn:mpeg:dash:profile:mp2t-simple:2011".</svrl:text>
+               <svrl:text>The On-Demand profile shall be identified by the URN "urn:mpeg:dash:profile:isoff-on-demand:2011". The live profile shall be identified by the URN "urn:mpeg:dash:profile:isoff-live:2011". The main profile shall be identified by the URN "urn:mpeg:dash:profile:isoff-main:2011". The full profile shall be identified by the URN "urn:mpeg:dash:profile:full:2011". The mp2t-main profile shall be identified by the URN "urn:mpeg:dash:profile:mp2t-main:2011". The mp2t-simple profile shall be identified by the URN "urn:mpeg:dash:profile:mp2t-simple:2011".The Dolby AC-4 profile shall be identified by "http://dashif.org/guidelines/dashif#ac-4".</svrl:text>
             </svrl:failed-assert>
          </xsl:otherwise>
       </xsl:choose>
@@ -982,12 +982,12 @@
 
 		    <!--ASSERT -->
 <xsl:choose>
-         <xsl:when test="if (not(@duration) and not(child::dash:SegmentTimeline)) then false() else true()"/>
+         <xsl:when test="if (not(@duration) and not(child::dash:SegmentTimeline) and not(@initialization) ) then false() else true()"/>
          <xsl:otherwise>
             <svrl:failed-assert xmlns:xs="http://www.w3.org/2001/XMLSchema"
                                 xmlns:schold="http://www.ascc.net/xml/schematron"
                                 xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
-                                test="if (not(@duration) and not(child::dash:SegmentTimeline)) then false() else true()">
+                                test="if (not(@duration) and not(child::dash:SegmentTimeline) and not(@initialization) ) then false() else true()">
                <xsl:attribute name="location">
                   <xsl:apply-templates select="." mode="schematron-get-full-path"/>
                </xsl:attribute>
@@ -1472,6 +1472,22 @@
                   <xsl:apply-templates select="." mode="schematron-get-full-path"/>
                </xsl:attribute>
                <svrl:text>If URI urn:mpeg:dash:outputChannelPositionList:2012 is used the value attribute shall be a space-delimited list as defined in ISO/IEC 23001-8.</svrl:text>
+            </svrl:failed-assert>
+         </xsl:otherwise>
+      </xsl:choose>
+
+		    <!--ASSERT -->
+<xsl:choose>
+         <xsl:when test="if (contains(ancestor::dash:MPD/@profiles, 'http://dashif.org/guidelines/dashif#ac-4') and not(@schemeIdUri='tag:dolby.com,2014:dash:audio_channel_configuration:2011')) then false() else true()"/>
+         <xsl:otherwise>
+            <svrl:failed-assert xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                                xmlns:schold="http://www.ascc.net/xml/schematron"
+                                xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
+                                test="if (contains(ancestor::dash:MPD/@profiles, 'http://dashif.org/guidelines/dashif#ac-4') and not(@schemeIdUri='tag:dolby.com,2014:dash:audio_channel_configuration:2011')) then false() else true()">
+               <xsl:attribute name="location">
+                  <xsl:apply-templates select="." mode="schematron-get-full-path"/>
+               </xsl:attribute>
+               <svrl:text> If profile http://dashif.org/guidelines/dashif#ac-4 is used, then schemeIdUri attribute shall be tag:dolby.com,2014:dash:audio_channel_configuration:2011.</svrl:text>
             </svrl:failed-assert>
          </xsl:otherwise>
       </xsl:choose>

--- a/conformance/MPDValidator/schematron/schematron.xsd
+++ b/conformance/MPDValidator/schematron/schematron.xsd
@@ -22,7 +22,7 @@
 			<!-- R1.6 -->
 			<assert test="if (@type = 'static' and @minimumUpdatePeriod) then false() else true()">If MPD is of type "static" minimumUpdatePeriod shall not be defined.</assert>
 			<!-- R1.7 -->
-			<assert test="if (not(@profiles) or (contains(@profiles, 'urn:mpeg:dash:profile:isoff-on-demand:2011') or contains(@profiles, 'urn:mpeg:dash:profile:isoff-live:2011') or contains(@profiles, 'urn:mpeg:dash:profile:isoff-main:2011') or contains(@profiles, 'urn:mpeg:dash:profile:full:2011') or contains(@profiles, 'urn:mpeg:dash:profile:mp2t-main:2011') or contains(@profiles, 'urn:mpeg:dash:profile:mp2t-simple:2011'))) then true() else false()">The On-Demand profile shall be identified by the URN "urn:mpeg:dash:profile:isoff-on-demand:2011". The live profile shall be identified by the URN "urn:mpeg:dash:profile:isoff-live:2011". The main profile shall be identified by the URN "urn:mpeg:dash:profile:isoff-main:2011". The full profile shall be identified by the URN "urn:mpeg:dash:profile:full:2011". The mp2t-main profile shall be identified by the URN "urn:mpeg:dash:profile:mp2t-main:2011". The mp2t-simple profile shall be identified by the URN "urn:mpeg:dash:profile:mp2t-simple:2011".</assert>
+			<assert test="if (not(@profiles) or (contains(@profiles, 'urn:mpeg:dash:profile:isoff-on-demand:2011') or contains(@profiles, 'urn:mpeg:dash:profile:isoff-live:2011') or contains(@profiles, 'urn:mpeg:dash:profile:isoff-main:2011') or contains(@profiles, 'urn:mpeg:dash:profile:full:2011') or contains(@profiles, 'urn:mpeg:dash:profile:mp2t-main:2011') or contains(@profiles, 'urn:mpeg:dash:profile:mp2t-simple:2011') or contains (@profiles, 'http://dashif.org/guidelines/dashif#ac-4'))) then true() else false()">The On-Demand profile shall be identified by the URN "urn:mpeg:dash:profile:isoff-on-demand:2011". The live profile shall be identified by the URN "urn:mpeg:dash:profile:isoff-live:2011". The main profile shall be identified by the URN "urn:mpeg:dash:profile:isoff-main:2011". The full profile shall be identified by the URN "urn:mpeg:dash:profile:full:2011". The mp2t-main profile shall be identified by the URN "urn:mpeg:dash:profile:mp2t-main:2011". The mp2t-simple profile shall be identified by the URN "urn:mpeg:dash:profile:mp2t-simple:2011".The Dolby AC-4 profile shall be identified by "http://dashif.org/guidelines/dashif#ac-4".</assert>
 			<!-- R1.8 -->
 			<assert test="if (not(contains(@profiles, 'urn:mpeg:dash:profile:isoff-on-demand:2011')) or not(@type) or @type='static') then true() else false()">For On-Demand profile, the MPD @type shall be "static".</assert>
             <!-- R1.9 -->
@@ -120,7 +120,7 @@
 		<!-- R7.*: Check the conformance of SegmentTemplate -->
 		<rule context="dash:SegmentTemplate">
 			<!-- R7.0 -->
-			<assert test="if (not(@duration) and not(child::dash:SegmentTimeline)) then false() else true()">If more than one Media Segment is present the duration attribute or SegmentTimeline element shall be present.</assert>
+			<assert test="if (not(@duration) and not(child::dash:SegmentTimeline) and not(@initialization) ) then false() else true()">If more than one Media Segment is present the duration attribute or SegmentTimeline element shall be present.</assert>
 			<!-- R7.1 -->
 			<assert test="if (@duration and child::dash:SegmentTimeline) then false() else true()">Either the duration attribute or SegmentTimeline element shall be present but not both.</assert>
 			<!-- R7.2 -->
@@ -205,6 +205,8 @@
 		<rule context="dash:AudioChannelConfiguration">
 			<!-- R15.0 -->
 			<assert test="if ((@schemeIdUri = 'urn:mpeg:dash:outputChannelPositionList:2012') and not(count(tokenize(@value, ' ')) > 1)) then false() else true()">If URI urn:mpeg:dash:outputChannelPositionList:2012 is used the value attribute shall be a space-delimited list as defined in ISO/IEC 23001-8.</assert>
+
+                        <assert test="if (contains(ancestor::dash:MPD/@profiles, 'http://dashif.org/guidelines/dashif#ac-4') and not(@schemeIdUri='tag:dolby.com,2014:dash:audio_channel_configuration:2011')) then false() else true()"> If profile http://dashif.org/guidelines/dashif#ac-4 is used, then schemeIdUri attribute shall be tag:dolby.com,2014:dash:audio_channel_configuration:2011.</assert >
 		</rule>
 	</pattern>
 	


### PR DESCRIPTION
Commits for following changes-
-schematron.xsd and val_schema.xsl changed to read 'initialization' even from AdaptationSet level, updated with ac-4.(Already committed in repo DashIF-Conformance-Software, commit/PR 003b9b1)
-ValidateMP4.h declares resolution and codecs parameters.
-ValidateMP4.cpp extracts resolution and codecs from inputs to SegmentValidator.
-ValidateAtoms.cpp updated with Checks for resolution(height,width) and ac-4.
-ValidateAtomList.cpp updated with Checks for ac-4.
The ValidateMP4.exe generated with these updates is already committed in DashIF-Conformance-Software, commit/PR 003b9b1.