### PR TITLE
Add missing parenthesis in sample_is_non_sync_sample

### DIFF
--- a/conformance/ISOSegmentValidator/public/src/PostprocessData.cpp
+++ b/conformance/ISOSegmentValidator/public/src/PostprocessData.cpp
@@ -971,7 +971,7 @@ OSErr processIndexingInfo(MovieInfoRec *mir)
                                 {
                                     samplePresentationTime = moof->trafInfo[k].trunInfo[l].samplePresentationTime[m];
 
-                                    bool sample_is_non_sync_sample = (moof->trafInfo[k].trunInfo[l].sample_flags[m] & 0x10000 >> 16) != 0;
+                                    bool sample_is_non_sync_sample = ((moof->trafInfo[k].trunInfo[l].sample_flags[m] & 0x10000) >> 16) != 0;
                                     UInt8 SAP_type = mir->sidxInfo[i].references[j].SAP_type;
                                     bool sample_is_SAP = mir->sidxInfo[i].references[j].SAP_type > 0 ? ((SAP_type == 1 || SAP_type == 2) && !sample_is_non_sync_sample) || (SAP_type == 3 && moof->trafInfo[k].trunInfo[l].sap3[m]) || (SAP_type == 4 && moof->trafInfo[k].trunInfo[l].sap4[m]) :
                                             !sample_is_non_sync_sample || moof->trafInfo[k].trunInfo[l].sap3[m] || moof->trafInfo[k].trunInfo[l].sap4[m];   //The latter case is with starts_with_SAP > 0 and unknown SAP type (0)


### PR DESCRIPTION
Currently SAP validator treats all samples as sync samples because >> have higher precedence than &