### PR TITLE
HEVC fixes

### DIFF
--- a/conformance/ISOSegmentValidator/public/src/ValidateBits.cpp
+++ b/conformance/ISOSegmentValidator/public/src/ValidateBits.cpp
@@ -112,7 +112,7 @@ UInt32 GetBits(BitBuffer *bb, UInt32 nBits, OSErr *errout)
 					goto bail;
 				}
 			}
-			else if (bb->cbyte == 0) bb->emulation_position += 1;
+			if (bb->cbyte == 0) bb->emulation_position += 1;
 			else bb->emulation_position = 0;
 		}
 	}


### PR DESCRIPTION
Fixed some bugs affecting HEVC decode.

- Fixed emulation prevention byte removal in the case where the first byte after an emulation prevention byte was a 0 and hence could be the start of a new sequence containing an emulation prevention byte.
- Fixed algorithm for skipping bytes of NAL units based on nal_length.  (The length already accounts for any emulation prevention bytes.)
- Fixed processing of rbsp_trailing_bits.
- Fixed some cases of uninitialized local variables being read.
- Fixed some cases of missing braces on if-statement body causing unintended (although probably harmless) execution of error testing and handling.
- Fixed some code causing compiler warnings.